### PR TITLE
Add support for setting the "pg_audit.log" configuration setting for roles

### DIFF
--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -122,6 +122,7 @@ resource "postgresql_role" "update_role" {
   statement_timeout = 30000
   idle_in_transaction_session_timeout = 60000
   assume_role = "${postgresql_role.group_role.name}"
+  pg_audit_log = "all, -read"
 }
 `
 	resource.Test(t, resource.TestCase{
@@ -146,6 +147,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", ""),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "pg_audit_log", ""),
 					testAccCheckRoleCanLogin(t, "update_role", "toto"),
 				),
 			},
@@ -167,6 +169,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "30000"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "60000"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", "group_role"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "pg_audit_log", "all, -read"),
 					testAccCheckRoleCanLogin(t, "update_role2", "titi"),
 				),
 			},
@@ -185,6 +188,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "idle_in_transaction_session_timeout", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "assume_role", ""),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "pg_audit_log", ""),
 					testAccCheckRoleCanLogin(t, "update_role", "toto"),
 				),
 			},

--- a/website/docs/r/postgresql_role.html.markdown
+++ b/website/docs/r/postgresql_role.html.markdown
@@ -118,6 +118,8 @@ resource "postgresql_role" "my_replication_role" {
 
 * `assume_role` - (Optional) Defines the role to switch to at login via [`SET ROLE`](https://www.postgresql.org/docs/current/sql-set-role.html).
 
+* `pg_audit_log` - (Optional) Controls the behavior of the [`pg_audit`](https://github.com/pgaudit/pgaudit) logging by setting the [`pg_audit.log`](https://github.com/pgaudit/pgaudit/blob/master/README.md#pgauditlog) parameter.
+
 ## Import Example
 
 `postgresql_role` supports importing resources.  Supposing the following


### PR DESCRIPTION
This follows the patten of how other configuration options are set, e.g. `statement_timeout`. Implements https://github.com/cyrilgdn/terraform-provider-postgresql/issues/529